### PR TITLE
FIX: daal4py sycl examples

### DIFF
--- a/scripts/build_backend.py
+++ b/scripts/build_backend.py
@@ -81,11 +81,11 @@ def build_cpp(cc, cxx, sources, targetprefix, targetname, targetsuffix, libs, li
             out = [f'/Fo{objfiles[i]}']
         else:
             out = ['-o', objfiles[i]]
-        cmd = [cc] + include_dir_plat + eca + [f'{d4p_dir}/{cppfile}'] + out + defines
+        cmd = [cc] + eca + include_dir_plat + [f'{d4p_dir}/{cppfile}'] + out + defines
         log.info(subprocess.list2cmdline(cmd))
         subprocess.check_call(cmd)
 
-    cmd = [cxx] + objfiles + library_dir_plat + ela + libs + additional_linker_opts
+    cmd = [cxx] + ela + objfiles + library_dir_plat + libs + additional_linker_opts
     log.info(subprocess.list2cmdline(cmd))
     subprocess.check_call(cmd)
     shutil.copy(f'{targetprefix}{targetname}{targetsuffix}',


### PR DESCRIPTION
fix compiler ignores some flags on WIN

# Description
Please include a summary of the change. For large or complex changes please include enough information to introduce your change and explain motivation for it.

Changes proposed in this pull request:
-
-
-

 
