### PR TITLE
FEAT: raw input (=no input validation) dispatching

### DIFF
--- a/dependencies-dev
+++ b/dependencies-dev
@@ -3,5 +3,5 @@ Jinja2==3.1.4
 numpy==2.0.1 ; python_version <= '3.9'
 numpy==2.2.0 ; python_version > '3.9'
 pybind11==2.13.6
-cmake==3.31.1
+cmake==3.31.2
 setuptools==75.6.0

--- a/generator/wrappers.py
+++ b/generator/wrappers.py
@@ -106,6 +106,8 @@ no_constructor = {
     "algorithms::engines::mt19937::Batch": {"seed": ["size_t", "seed"]},
     "algorithms::engines::mt2203::Batch": {"seed": ["size_t", "seed"]},
     "algorithms::engines::mcg59::Batch": {"seed": ["size_t", "seed"]},
+    "algorithms::engines::mrg32k3a::Batch": {"seed": ["size_t", "seed"]},
+    "algorithms::engines::philox4x32x10::Batch": {"seed": ["size_t", "seed"]},
 }
 
 # Some algorithms require a setup function, to provide input without actual compute
@@ -883,6 +885,12 @@ no_warn = {
         "ParameterType",
     ],
     "algorithms::engines::mt2203": [
+        "ParameterType",
+    ],
+    "algorithms::engines::mrg32k3a": [
+        "ParameterType",
+    ],
+    "algorithms::engines::philox4x32x10": [
         "ParameterType",
     ],
     "algorithms::gbt": [

--- a/onedal/covariance/covariance.py
+++ b/onedal/covariance/covariance.py
@@ -127,6 +127,6 @@ class EmpiricalCovariance(BaseEmpiricalCovariance):
                 / X.shape[0]
             )
 
-        self.location_ = xp.reshape(from_table(result.means, sycl_queue=queue), -1)
+        self.location_ = from_table(result.means).ravel()
 
         return self

--- a/onedal/utils/tests/test_validation.py
+++ b/onedal/utils/tests/test_validation.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
-
 import numpy as np
 import numpy.random as rand
 import pytest
@@ -65,7 +63,7 @@ def test_sum_infinite_actually_finite(dtype, shape, allow_nan, dataframe, queue)
 )
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
 )
@@ -92,7 +90,7 @@ def test_assert_finite_random_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue", get_dataframes_and_queues("numpy,dpnp,dpctl")
 )
@@ -120,7 +118,7 @@ def test_assert_finite_random_shape_and_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("allow_nan", [False, True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 def test_assert_finite_sparse(dtype, allow_nan, check, seed):
     lb, ub = 2, 2056
     rand.seed(seed)

--- a/sklearnex/utils/tests/test_validation.py
+++ b/sklearnex/utils/tests/test_validation.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import time
-
 import numpy as np
 import numpy.random as rand
 import pytest
@@ -67,7 +65,7 @@ def test_sum_infinite_actually_finite(dtype, shape, ensure_all_finite):
 )
 @pytest.mark.parametrize("ensure_all_finite", ["allow-nan", True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),
@@ -110,7 +108,7 @@ def test_validate_data_random_location(
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("ensure_all_finite", ["allow-nan", True])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),
@@ -151,7 +149,7 @@ def test_validate_data_random_shape_and_location(
 
 @pytest.mark.parametrize("dtype", [np.float32, np.float64])
 @pytest.mark.parametrize("check", ["inf", "NaN", None])
-@pytest.mark.parametrize("seed", [0, int(time.time())])
+@pytest.mark.parametrize("seed", [0, 123456])
 @pytest.mark.parametrize(
     "dataframe, queue",
     get_dataframes_and_queues(_dataframes_supported),


### PR DESCRIPTION
## Description

This branches of `a8f3f196d040b99429a89e2cfc48ff4695dbd233` which the state of Samir's `enh/raw_inputs` branch after it passes all CIs.
This PR adds/restores the functionality of `use_raw_input` to some algos which didn't work after resolving the conflicts in https://github.com/uxlfoundation/scikit-learn-intelex/pull/2153.

**This PR is to be merged into Samir's fork before merging https://github.com/uxlfoundation/scikit-learn-intelex/pull/2153**.

---

PR should start as a draft, then move to ready for review state after CI is passed and all applicable checkboxes are closed.
This approach ensures that reviewers don't spend extra time asking for regular requirements.

You can remove a checkbox as not applicable only if it doesn't relate to this PR in any way.
For example, PR with docs update doesn't require checkboxes for performance while PR with any change in actual code should have checkboxes and justify how this code change is expected to affect performance (or justification should be self-evident).

Checklist to comply with **before moving PR from draft**:

**PR completeness and readability**

- [ ] I have reviewed my changes thoroughly before submitting this pull request.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have updated the documentation to reflect the changes or created a separate PR with update and provided its number in the description, if necessary.
- [ ] Git commit message contains an appropriate signed-off-by string _(see [CONTRIBUTING.md](https://github.com/uxlfoundation/scikit-learn-intelex/blob/main/CONTRIBUTING.md#pull-requests) for details)_.
- [ ] I have added a respective label(s) to PR if I have a permission for that.
- [ ] I have resolved any merge conflicts that might occur with the base branch.

**Testing**

- [ ] I have run it locally and tested the changes extensively.
- [ ] All CI jobs are green or I have provided justification why they aren't.
- [ ] I have extended testing suite if new functionality was introduced in this PR.

**Performance**

- [ ] I have measured performance for affected algorithms using [scikit-learn_bench](https://github.com/IntelPython/scikit-learn_bench) and provided at least summary table with measured data, if performance change is expected.
- [ ] I have provided justification why performance has changed or why changes are not expected.
- [ ] I have provided justification why quality metrics have changed or why changes are not expected.
- [ ] I have extended benchmarking suite and provided corresponding scikit-learn_bench PR if new measurable functionality was introduced in this PR.
